### PR TITLE
Add missing spidev package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ pyzmq==17.1.2
 requests==2.21.0
 singledispatch==3.4.0.3
 six==1.12.0
+spidev==3.4
 urllib3==1.24.2
 wrapt==1.11.1
 https://github.com/gotenna/PublicSDK/raw/master/python-public-sdk/goTenna-0.12.5-py2-none-any.whl ; sys_platform == "linux"


### PR DESCRIPTION
Discovered during my testing of the gotenna mesh on the nodl.

```
(txtenna) root@nodl:~/txtenna-python# python txtenna.py --gateway --local <SDK TOKEN> 2
Traceback (most recent call last):
  File "txtenna.py", line 17, in <module>
    import goTenna # The goTenna API
  File "/root/.virtualenvs/txtenna/local/lib/python2.7/site-packages/goTenna/__init__.py", line 32, in <module>
    from goTenna import spi_connection
  File "/root/.virtualenvs/txtenna/local/lib/python2.7/site-packages/goTenna/spi_connection.py", line 34, in <module>
    import spidev
ImportError: No module named spidev
```
Adding the respective module to requirements fixes the issue.